### PR TITLE
Simplify build files

### DIFF
--- a/templates/service/project/FrontendBuild.scala
+++ b/templates/service/project/FrontendBuild.scala
@@ -2,21 +2,12 @@ import sbt._
 import uk.gov.hmrc.SbtAutoBuildPlugin
 import uk.gov.hmrc.sbtdistributables.SbtDistributablesPlugin
 import uk.gov.hmrc.versioning.SbtGitVersioning
+import play.PlayImport._
+import play.core.PlayVersion
 
 object FrontendBuild extends Build with MicroService {
 
   val appName = "$!APP_NAME!$"
-
-  override lazy val plugins: Seq[Plugins] = Seq(
-    SbtAutoBuildPlugin, SbtGitVersioning, SbtDistributablesPlugin
-  )
-
-  override lazy val appDependencies: Seq[ModuleID] = AppDependencies()
-}
-
-private object AppDependencies {
-  import play.PlayImport._
-  import play.core.PlayVersion
 
   private val playHealthVersion = "$!playHealthVersion!$"    
   private val playJsonLoggerVersion = "$!playJsonLoggerVersion!$"      
@@ -27,7 +18,13 @@ private object AppDependencies {
   private val playAuthorisedFrontendVersion = "$!playAuthorisedFrontendVersion!$"
   private val playConfigVersion = "$!playConfigVersion!$"
   private val hmrcTestVersion = "$!hmrcTestVersion!$"
-  
+
+  override lazy val plugins: Seq[Plugins] = Seq(
+    SbtAutoBuildPlugin, SbtGitVersioning, SbtDistributablesPlugin
+  )
+
+  override lazy val appDependencies: Seq[ModuleID] = compile ++ testDependencies
+
   val compile = Seq(
     ws,
     "uk.gov.hmrc" %% "frontend-bootstrap" % frontendBootstrapVersion,
@@ -40,24 +37,16 @@ private object AppDependencies {
     "uk.gov.hmrc" %% "play-ui" % playUiVersion
   )
 
-  trait TestDependencies {
-    lazy val scope: String = "test"
-    lazy val test : Seq[ModuleID] = ???
-  }
+  val testDependencies: Seq[ModuleID] = baseTestDependencies("test")
 
-  object Test {
-    def apply() = new TestDependencies {
-      override lazy val test = Seq(
-        "uk.gov.hmrc" %% "hmrctest" % hmrcTestVersion % scope,
-        "org.scalatest" %% "scalatest" % "2.2.2" % scope,
-        "org.pegdown" % "pegdown" % "1.4.2" % scope,
-        "org.jsoup" % "jsoup" % "1.7.3" % scope,
-        "com.typesafe.play" %% "play-test" % PlayVersion.current % scope
-      )
-    }.test
-  }
+  private def baseTestDependencies(scope: String): Seq[ModuleID] = Seq(
+    "uk.gov.hmrc" %% "hmrctest" % hmrcTestVersion % scope,
+    "org.scalatest" %% "scalatest" % "2.2.2" % scope,
+    "org.pegdown" % "pegdown" % "1.4.2" % scope,
+    "org.jsoup" % "jsoup" % "1.7.3" % scope,
+    "com.typesafe.play" %% "play-test" % PlayVersion.current % scope
+  )
 
-  def apply() = compile ++ Test()
 }
 
 

--- a/templates/service/project/MicroServiceBuild.scala
+++ b/templates/service/project/MicroServiceBuild.scala
@@ -2,21 +2,12 @@ import sbt._
 import uk.gov.hmrc.SbtAutoBuildPlugin
 import uk.gov.hmrc.sbtdistributables.SbtDistributablesPlugin
 import uk.gov.hmrc.versioning.SbtGitVersioning
+import play.PlayImport._
+import play.core.PlayVersion
 
 object MicroServiceBuild extends Build with MicroService {
 
   val appName = "$!APP_NAME!$"
-
-  override lazy val plugins: Seq[Plugins] = Seq(
-    SbtAutoBuildPlugin, SbtGitVersioning, SbtDistributablesPlugin
-  )
-
-  override lazy val appDependencies: Seq[ModuleID] = AppDependencies()
-}
-
-private object AppDependencies {
-  import play.PlayImport._
-  import play.core.PlayVersion
 
   private val microserviceBootstrapVersion = "$!microserviceBootstrapVersion!$"
   private val playAuthVersion = "$!playAuthVersion!$"
@@ -29,6 +20,12 @@ private object AppDependencies {
   <!--(if MONGO)-->
   private val playReactivemongoVersion = "$!playReactivemongoVersion!$"
   <!--(end)-->
+
+  override lazy val plugins: Seq[Plugins] = Seq(
+    SbtAutoBuildPlugin, SbtGitVersioning, SbtDistributablesPlugin
+  )
+
+  override lazy val appDependencies: Seq[ModuleID] = compile ++ testDependencies ++ itDependencies
 
   val compile = Seq(
     <!--(if MONGO)-->
@@ -45,36 +42,16 @@ private object AppDependencies {
     "uk.gov.hmrc" %% "domain" % domainVersion
   )
 
-  trait TestDependencies {
-    lazy val scope: String = "test"
-    lazy val test : Seq[ModuleID] = ???
-  }
+  val testDependencies: Seq[ModuleID] = baseTestDependencies("test")
 
-  object Test {
-    def apply() = new TestDependencies {
-      override lazy val test = Seq(
-        "uk.gov.hmrc" %% "hmrctest" % hmrcTestVersion % scope,
-        "org.scalatest" %% "scalatest" % "2.2.2" % scope,
-        "org.pegdown" % "pegdown" % "1.4.2" % scope,        
-        "com.typesafe.play" %% "play-test" % PlayVersion.current % scope
-      )
-    }.test
-  }
+  val itDependencies: Seq[ModuleID] = baseTestDependencies("it")
 
-  object IntegrationTest {
-    def apply() = new TestDependencies {
+  private def baseTestDependencies(scope: String): Seq[ModuleID] = Seq(
+    "uk.gov.hmrc" %% "hmrctest" % hmrcTestVersion % scope,
+    "org.scalatest" %% "scalatest" % "2.2.2" % scope,
+    "org.pegdown" % "pegdown" % "1.4.2" % scope,
+    "org.jsoup" % "jsoup" % "1.7.3" % scope,
+    "com.typesafe.play" %% "play-test" % PlayVersion.current % scope
+  )
 
-      override lazy val scope: String = "it"
-
-      override lazy val test = Seq(
-        "uk.gov.hmrc" %% "hmrctest" % hmrcTestVersion % scope,
-        "org.scalatest" %% "scalatest" % "2.2.2" % scope,
-        "org.pegdown" % "pegdown" % "1.4.2" % scope,
-        "com.typesafe.play" %% "play-test" % PlayVersion.current % scope
-      )
-    }.test
-  }
-
-  def apply() = compile ++ Test() ++ IntegrationTest()
 }
-


### PR DESCRIPTION
The current build file templates seem unnecessarily obscure and obfuscatory in their use of a private object with apply method to generate dependency sequences. All this really achieves is the differentiation of scope value between "test" and "it" dependencies in MicroserviceBuild. The code can be greatly simplified by just using a function that takes the scope for the test deps as a parameter and concatenating simple sequences to generate the full set of dependencies.
