### PR TITLE
[SDT-38] Remove assetsPrefix and bump play-ui

### DIFF
--- a/templates/service/app/config/frontendAppConfig.scala
+++ b/templates/service/app/config/frontendAppConfig.scala
@@ -4,7 +4,6 @@ import play.api.Play.{configuration, current}
 import uk.gov.hmrc.play.config.ServicesConfig
 
 trait AppConfig {
-  val assetsPrefix: String
   val analyticsToken: String
   val analyticsHost: String
   val reportAProblemPartialUrl: String
@@ -18,7 +17,6 @@ object FrontendAppConfig extends AppConfig with ServicesConfig {
   private val contactHost = configuration.getString(s"contact-frontend.host").getOrElse("")
   private val contactFormServiceIdentifier = "MyService"
 
-  override lazy val assetsPrefix = loadConfig(s"assets.url") + loadConfig(s"assets.version")
   override lazy val analyticsToken = loadConfig(s"google-analytics.token")
   override lazy val analyticsHost = loadConfig(s"google-analytics.host")
   override lazy val reportAProblemPartialUrl = s"$contactHost/contact/problem_reports_ajax?service=$contactFormServiceIdentifier"

--- a/templates/service/app/views/govuk_wrapper.scala.html
+++ b/templates/service/app/views/govuk_wrapper.scala.html
@@ -15,7 +15,6 @@
 
 @head = {
     @uiLayouts.head(
-      assetsPrefix = appConfig.assetsPrefix,
       linkElem = None,
       headScripts = None)
     <meta name="format-detection" content="telephone=no" />
@@ -40,7 +39,6 @@
     @uiLayouts.footer(
       analyticsToken = Some(appConfig.analyticsToken),
       analyticsHost = appConfig.analyticsHost,
-      assetsPrefix = appConfig.assetsPrefix,
       ssoUrl = None,
       scriptElem = scriptElem,
       gaCalls = None)


### PR DESCRIPTION
Remove `assetsPrefix` work and bump to next `play 2.3` `play-ui` release. As per https://github.com/hmrc/play-ui/pull/61

This is for review by @hmrc/platops
