### PR TITLE
Simplify build files

### DIFF
--- a/templates/service/project/FrontendBuild.scala
+++ b/templates/service/project/FrontendBuild.scala
@@ -1,4 +1,6 @@
 import sbt._
+import play.sbt.PlayImport._
+import play.core.PlayVersion
 import uk.gov.hmrc.SbtAutoBuildPlugin
 import uk.gov.hmrc.sbtdistributables.SbtDistributablesPlugin
 import uk.gov.hmrc.versioning.SbtGitVersioning
@@ -7,53 +9,26 @@ object FrontendBuild extends Build with MicroService {
 
   val appName = "$!APP_NAME!$"
 
-  override lazy val appDependencies: Seq[ModuleID] = AppDependencies()
-}
-
-private object AppDependencies {
-  import play.sbt.PlayImport._
-  import play.core.PlayVersion
-
-  private val playHealthVersion = "$!playHealthVersion!$"
-  private val logbackJsonLoggerVersion = "$!logbackJsonLoggerVersion!$"
-  private val frontendBootstrapVersion = "$!frontendBootstrapVersion!$"
-  private val govukTemplateVersion = "$!govukTemplateVersion!$"
-  private val playUiVersion = "$!playUiVersion!$"
-  private val playPartialsVersion = "$!playPartialsVersion!$"
-  private val playAuthorisedFrontendVersion = "$!playAuthorisedFrontendVersion!$"
-  private val playConfigVersion = "$!playConfigVersion!$"
-  private val hmrcTestVersion = "$!hmrcTestVersion!$"
-  private val scalaTestVersion = "2.2.6"
-  private val pegdownVersion = "1.6.0"
+  override lazy val appDependencies: Seq[ModuleID] = compile ++ test()
 
   val compile = Seq(
     ws,
-    "uk.gov.hmrc" %% "frontend-bootstrap" % frontendBootstrapVersion,
-    "uk.gov.hmrc" %% "play-partials" % playPartialsVersion,
-    "uk.gov.hmrc" %% "play-authorised-frontend" % playAuthorisedFrontendVersion,
-    "uk.gov.hmrc" %% "play-config" % playConfigVersion,
-    "uk.gov.hmrc" %% "logback-json-logger" % logbackJsonLoggerVersion,
-    "uk.gov.hmrc" %% "govuk-template" % govukTemplateVersion,
-    "uk.gov.hmrc" %% "play-health" % playHealthVersion,
-    "uk.gov.hmrc" %% "play-ui" % playUiVersion
+    "uk.gov.hmrc" %% "frontend-bootstrap" % "$!frontendBootstrapVersion!$",
+    "uk.gov.hmrc" %% "play-partials" % "$!playPartialsVersion!$",
+    "uk.gov.hmrc" %% "play-authorised-frontend" % "$!playAuthorisedFrontendVersion!$",
+    "uk.gov.hmrc" %% "play-config" % "$!playConfigVersion!$",
+    "uk.gov.hmrc" %% "logback-json-logger" % "$!logbackJsonLoggerVersion!$",
+    "uk.gov.hmrc" %% "govuk-template" % "$!govukTemplateVersion!$",
+    "uk.gov.hmrc" %% "play-health" % "$!playHealthVersion!$",
+    "uk.gov.hmrc" %% "play-ui" % "$!playUiVersion!$"
   )
 
-  trait TestDependencies {
-    lazy val scope: String = "test"
-    lazy val test : Seq[ModuleID] = ???
-  }
+  def test(scope: String = "test") = Seq(
+    "uk.gov.hmrc" %% "hmrctest" % "$!hmrcTestVersion!$" % scope,
+    "org.scalatest" %% "scalatest" % "2.2.6" % scope,
+    "org.pegdown" % "pegdown" % "1.6.0" % scope,
+    "org.jsoup" % "jsoup" % "1.8.1" % scope,
+    "com.typesafe.play" %% "play-test" % PlayVersion.current % scope
+  )
 
-  object Test {
-    def apply() = new TestDependencies {
-      override lazy val test = Seq(
-        "uk.gov.hmrc" %% "hmrctest" % hmrcTestVersion % scope,
-        "org.scalatest" %% "scalatest" % scalaTestVersion % scope,
-        "org.pegdown" % "pegdown" % pegdownVersion % scope,
-        "org.jsoup" % "jsoup" % "1.8.1" % scope,
-        "com.typesafe.play" %% "play-test" % PlayVersion.current % scope
-      )
-    }.test
-  }
-
-  def apply() = compile ++ Test()
 }

--- a/templates/service/project/MicroServiceBuild.scala
+++ b/templates/service/project/MicroServiceBuild.scala
@@ -1,4 +1,6 @@
 import sbt._
+import play.sbt.PlayImport._
+import play.core.PlayVersion
 import uk.gov.hmrc.SbtAutoBuildPlugin
 import uk.gov.hmrc.sbtdistributables.SbtDistributablesPlugin
 import uk.gov.hmrc.versioning.SbtGitVersioning
@@ -7,72 +9,27 @@ object MicroServiceBuild extends Build with MicroService {
 
   val appName = "$!APP_NAME!$"
 
-  override lazy val appDependencies: Seq[ModuleID] = AppDependencies()
-}
-
-private object AppDependencies {
-  import play.sbt.PlayImport._
-  import play.core.PlayVersion
-
-  private val microserviceBootstrapVersion = "$!microserviceBootstrapVersion!$"
-  private val playAuthVersion = "$!playAuthVersion!$"
-  private val playHealthVersion = "$!playHealthVersion!$"
-  private val logbackJsonLoggerVersion = "$!logbackJsonLoggerVersion!$"
-  private val playUrlBindersVersion = "$!playUrlBindersVersion!$"
-  private val playConfigVersion = "$!playConfigVersion!$"
-  private val domainVersion = "$!domainVersion!$"
-  private val hmrcTestVersion = "$!hmrcTestVersion!$"
-  private val scalaTestVersion = "2.2.6"
-  private val pegdownVersion = "1.6.0"
-
-  <!--(if MONGO)-->
-  private val playReactivemongoVersion = "$!playReactivemongoVersion!$"
-  <!--(end)-->
+  override lazy val appDependencies: Seq[ModuleID] = compile ++ test()
 
   val compile = Seq(
     <!--(if MONGO)-->
-    "uk.gov.hmrc" %% "play-reactivemongo" % playReactivemongoVersion,
+    "uk.gov.hmrc" %% "play-reactivemongo" % "$!playReactivemongoVersion!$",
     <!--(end)-->
-
     ws,
-    "uk.gov.hmrc" %% "microservice-bootstrap" % microserviceBootstrapVersion,
-    "uk.gov.hmrc" %% "play-authorisation" % playAuthVersion,
-    "uk.gov.hmrc" %% "play-health" % playHealthVersion,
-    "uk.gov.hmrc" %% "play-url-binders" % playUrlBindersVersion,
-    "uk.gov.hmrc" %% "play-config" % playConfigVersion,
-    "uk.gov.hmrc" %% "logback-json-logger" % logbackJsonLoggerVersion,
-    "uk.gov.hmrc" %% "domain" % domainVersion
+    "uk.gov.hmrc" %% "microservice-bootstrap" % "$!microserviceBootstrapVersion!$",
+    "uk.gov.hmrc" %% "play-authorisation" % "$!playAuthVersion!$",
+    "uk.gov.hmrc" %% "play-health" % "$!playHealthVersion!$",
+    "uk.gov.hmrc" %% "play-url-binders" % "$!playUrlBindersVersion!$",
+    "uk.gov.hmrc" %% "play-config" % "$!playConfigVersion!$",
+    "uk.gov.hmrc" %% "logback-json-logger" % "$!logbackJsonLoggerVersion!$",
+    "uk.gov.hmrc" %% "domain" % "$!domainVersion!$"
   )
 
-  trait TestDependencies {
-    lazy val scope: String = "test"
-    lazy val test : Seq[ModuleID] = ???
-  }
+  def test(scope: String = "test,it") = Seq(
+    "uk.gov.hmrc" %% "hmrctest" % "$!hmrcTestVersion!$" % scope,
+    "org.scalatest" %% "scalatest" % "2.2.6" % scope,
+    "org.pegdown" % "pegdown" % "1.6.0" % scope,
+    "com.typesafe.play" %% "play-test" % PlayVersion.current % scope
+  )
 
-  object Test {
-    def apply() = new TestDependencies {
-      override lazy val test = Seq(
-        "uk.gov.hmrc" %% "hmrctest" % hmrcTestVersion % scope,
-        "org.scalatest" %% "scalatest" % scalaTestVersion % scope,
-        "org.pegdown" % "pegdown" % pegdownVersion % scope,
-        "com.typesafe.play" %% "play-test" % PlayVersion.current % scope
-      )
-    }.test
-  }
-
-  object IntegrationTest {
-    def apply() = new TestDependencies {
-
-      override lazy val scope: String = "it"
-
-      override lazy val test = Seq(
-        "uk.gov.hmrc" %% "hmrctest" % hmrcTestVersion % scope,
-        "org.scalatest" %% "scalatest" % scalaTestVersion % scope,
-        "org.pegdown" % "pegdown" % pegdownVersion % scope,
-        "com.typesafe.play" %% "play-test" % PlayVersion.current % scope
-      )
-    }.test
-  }
-
-  def apply() = compile ++ Test() ++ IntegrationTest()
 }

--- a/templates/service/project/StubServiceBuild.scala
+++ b/templates/service/project/StubServiceBuild.scala
@@ -1,5 +1,6 @@
 import sbt._
-
+import play.sbt.PlayImport._
+import play.core.PlayVersion
 
 object StubServiceBuild extends Build with MicroService {
   import scala.util.Properties.envOrElse
@@ -7,45 +8,21 @@ object StubServiceBuild extends Build with MicroService {
   val appName = "$!APP_NAME!$"
   val appVersion = envOrElse("$!UPPER_CASE_APP_NAME_UNDERSCORE_ONLY!$_VERSION", "999-SNAPSHOT")
 
-  override lazy val appDependencies: Seq[ModuleID] = AppDependencies()
-}
-
-private object AppDependencies {
-  import play.sbt.PlayImport._
-  import play.core.PlayVersion
-
-
-  private val microserviceBootstrapVersion = "$!microserviceBootstrapVersion!$"
-  private val playHealthVersion = "$!playHealthVersion!$"
-  private val playConfigVersion = "$!playConfigVersion!$"
-  private val logbackJsonLoggerVersion = "$!logbackJsonLoggerVersion!$"
-  private val hmrcTestVersion = "$!hmrcTestVersion!$"
-  private val scalaTestVersion = "2.2.6"
-  private val pegdownVersion = "1.6.0"
+  override lazy val appDependencies: Seq[ModuleID] = compile ++ test()
 
   val compile = Seq(
     ws,
-    "uk.gov.hmrc" %% "microservice-bootstrap" % microserviceBootstrapVersion,
-    "uk.gov.hmrc" %% "play-health" % playHealthVersion,
-    "uk.gov.hmrc" %% "play-config" % playConfigVersion,
-    "uk.gov.hmrc" %% "logback-json-logger" % logbackJsonLoggerVersion
+    "uk.gov.hmrc" %% "microservice-bootstrap" % "$!microserviceBootstrapVersion!$",
+    "uk.gov.hmrc" %% "play-health" % "$!playHealthVersion!$",
+    "uk.gov.hmrc" %% "play-config" % "$!playConfigVersion!$",
+    "uk.gov.hmrc" %% "logback-json-logger" % "$!logbackJsonLoggerVersion!$"
   )
 
-  trait TestDependencies {
-    lazy val scope: String = "test"
-    lazy val test : Seq[ModuleID] = ???
-  }
+  def test(scope: String = "test") = Seq(
+    "uk.gov.hmrc" %% "hmrctest" % "$!hmrcTestVersion!$" % scope,
+    "org.scalatest" %% "scalatest" % "2.2.6" % scope,
+    "org.pegdown" % "pegdown" % "1.6.0" % scope,
+    "com.typesafe.play" %% "play-test" % PlayVersion.current % scope
+  )
 
-  object Test {
-    def apply() = new TestDependencies {
-      override lazy val test = Seq(
-        "uk.gov.hmrc" %% "hmrctest" % hmrcTestVersion % scope,
-        "org.scalatest" %% "scalatest" % scalaTestVersion % scope,
-        "org.pegdown" % "pegdown" % pegdownVersion % scope,
-        "com.typesafe.play" %% "play-test" % PlayVersion.current % scope
-      )
-    }.test
-  }
-
-  def apply() = compile ++ Test()
 }


### PR DESCRIPTION
The build file templates contain a lot of unnecessary code. This PR contains changes to syntactically simplify these files whilst retaining their intent of enabling test scope dependency sequence to potentially be added to the dependency set multiple times with different scopes (although that is also probably unnecessary).