### PR TITLE
refactor the uiLayouts.footer_links call to sue the footerLinks variable

### DIFF
--- a/templates/service/app/views/govuk_wrapper.scala.html
+++ b/templates/service/app/views/govuk_wrapper.scala.html
@@ -45,7 +45,9 @@
 }
 
 @footerTop = {}
-@footerLinks = {}
+@footerLinks = {
+    uiLayouts.footer_links()
+}
 
 @serviceInfo = {
     @uiLayouts.serviceInfo(
@@ -73,4 +75,4 @@
       sidebar = sidebar)
 }
 
-@hmrcGovUkTemplate(Some(title), bodyClasses)(head, bodyEnd, insideHeader, afterHeader, footerTop, Some(uiLayouts.footer_links()), true)(content)
+@hmrcGovUkTemplate(Some(title), bodyClasses)(head, bodyEnd, insideHeader, afterHeader, footerTop, Some(footerLinks), true)(content)


### PR DESCRIPTION
👋  
We are currently documenting how the frontend parts fit together, this is a small PR to assign the `  uiLayouts.footer_links()` call to the `footerLinks` variable. Rather than the `footerLinks` variable being bypassed. This will make it a little easier to explain.