### PR TITLE
Don't set play.crypto.secret in frontends

### DIFF
--- a/templates/service/conf/application.conf
+++ b/templates/service/conf/application.conf
@@ -25,7 +25,10 @@ play.http.requestHandler = "play.api.http.GlobalSettingsHttpRequestHandler"
 # ~~~~~
 # The secret key is used to secure cryptographics functions.
 # If you deploy your application to several instances be sure to use the same key!
-play.crypto.secret="$!SECRET_KEY!$"
+# Not set here so that MDTP frontends share the same secret key in the local environment
+# (see common.conf in frontend-bootstrap).
+# In server environments the secret comes from app-config-common
+# play.crypto.secret="$!SECRET_KEY!$"
 
 microservice {
     metrics {


### PR DESCRIPTION
...so that they can interoperate with each other when running locally.

When a frontend has its own secret and logged-in-only endpoints are implemented then the frontend redirects back to company-auth-frontend even when a user has just logged in.