### PR TITLE
PLATUI-1166: Update to default i18n configuration for new services to…

### DIFF
--- a/templates/service/conf/application.conf
+++ b/templates/service/conf/application.conf
@@ -90,11 +90,15 @@ controllers {
   }
 }
 
-play.i18n.langs = ["en", "cy"]
 play.i18n.langCookieHttpOnly: "true"
 
 # Change this value to true to enable Welsh translations to be loaded from messages.cy, and to display the language toggle
 features.welsh-language-support = false
+
+# Replace play.i18n.langs with the commented out line below when your service has been fully translated into Welsh
+# to enable Welsh translations for all content, including the standard headers and footers.
+# play.i18n.langs = ["en", "cy"]
+play.i18n.langs = ["en"]
 
 # To integrate with tracking-consent-frontend, uncomment and update the
 # gtm.container property below to be one of a, b, c, d, e, f or sdes


### PR DESCRIPTION
… fix WCAG 2.1 violation

Before this change, new services not yet translated into Welsh would have
standard headers and footers translated into Welsh but no other content - for example the service name, back links and main content. This is a violation of WCAG 2.1 Success Criterion 3.1.2: Language of Parts:
https://www.w3.org/WAI/WCAG21/Understanding/language-of-parts.html

Without a reliable, automatic way to add the correct lang attribute to untranslated parts,
the decision was taken to default new services to render consistently in the English language
until fully translated.