### PR TITLE
Cleanup logback configuration file for new microservices 

### DIFF
--- a/init_service/templates/service/conf/logback.xml
+++ b/init_service/templates/service/conf/logback.xml
@@ -14,23 +14,13 @@
         </encoder>
     </appender>
 
-    <appender name="CONNECTOR_LOG_FILE" class="ch.qos.logback.core.FileAppender">
-        <file>logs/connector.log</file>
-        <encoder>
-            <pattern>%message%n</pattern>
-        </encoder>
-    </appender>
-
-
     <logger name="com.google.inject" level="INFO"/>
 
     <logger name="uk.gov" level="INFO"/>
 
     <logger name="application" level="DEBUG"/>
 
-    <logger name="connector" level="TRACE">
-        <appender-ref ref="STDOUT"/>
-    </logger>
+    <logger name="connector" level="TRACE"/>
 
     <root level="INFO">
         <appender-ref ref="FILE"/>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "init-service"
-version = "0.25.0"
+version = "0.26.0"
 description = "A templating tool for HMRC MDTP repositories"
 authors = ["Your Name <you@example.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
This PR will clean up the logback configuration file by:

- Removing unused appenders (`CONNECTOR_LOG_FILE`)
- Prevent unnecessary duplication of data through logback inheritance (`connector`)

Merging thia PR will mean that service teams do not need to remember to perform these steps when they create a new service using Catalogue. 